### PR TITLE
Fix: Include all non-paid invoice statuses in quick payment

### DIFF
--- a/src/components/payments/QuickPaymentRecording.tsx
+++ b/src/components/payments/QuickPaymentRecording.tsx
@@ -94,7 +94,7 @@ export function QuickPaymentRecording() {
           contracts (contract_number)
         `)
         .eq('customer_id', customer.id)
-        .eq('status', 'unpaid')
+        .in('status', ['unpaid', 'pending', 'overdue', 'partially_paid'])
         .order('due_date', { ascending: true });
 
       if (error) throw error;


### PR DESCRIPTION
Fixes issue where invoices with status pending, overdue, or partially_paid were not showing up in quick payment search