### PR TITLE
fix: عرض فواتير الشهر الحالي في صفحة الدفع السريع

### DIFF
--- a/src/components/payments/QuickPaymentRecording.tsx
+++ b/src/components/payments/QuickPaymentRecording.tsx
@@ -446,6 +446,8 @@ export function QuickPaymentRecording({ onStepChange }: QuickPaymentRecordingPro
     try {
       // تحديد تاريخ اليوم لفلترة الفواتير المستحقة فقط
       const today = new Date().toISOString().split('T')[0];
+      const monthStart = startOfMonth(new Date()).toISOString().split('T')[0];
+      const monthEnd = endOfMonth(new Date()).toISOString().split('T')[0];
 
       const { data, error } = await supabase
         .from('invoices')
@@ -471,7 +473,8 @@ export function QuickPaymentRecording({ onStepChange }: QuickPaymentRecordingPro
         .eq('contract_id', contract.id)  // فلترة حسب العقد المختار
         .in('payment_status', ['unpaid', 'partial', 'overdue', 'pending'])
         .neq('status', 'cancelled')
-        .lte('due_date', today)  // ✅ عرض الفواتير المستحقة حتى اليوم فقط (لا فواتير مستقبلية)
+        .gte('invoice_date', monthStart)  // ✅ عرض فواتير الشهر الحالي فصاعداً
+        .lte('due_date', monthEnd)        // ✅ مستحقة حتى نهاية الشهر الحالي
         .order('due_date', { ascending: true });
 
       if (error) throw error;


### PR DESCRIPTION
## المشكلة
فواتير شهر أبريل لا تظهر في صفحة `/finance/payments/quick` عند البحث عن عملاء.

## السبب
في `QuickPaymentRecording.tsx` سطر 474، الاستعلام يفلتر بـ `due_date <= today`. معظم فواتير أبريل لها `due_date = 2026-05-01` (بداية الشهر التالي)، فالنظام يخفيها لأنها "مستقبلية".

## الحل
تغيير الفلتر ليعرض فواتير الشهر الحالي:
- `invoice_date >= startOfMonth()` (من بداية الشهر)
- `due_date <= endOfMonth()` (حتى نهاية الشهر)

## التغييرات
- `src/components/payments/QuickPaymentRecording.tsx`: تعديل سطر 474

## ملاحظات
- `startOfMonth` و `endOfMonth` مستوردين أصلاً من `date-fns` في نفس الملف